### PR TITLE
Add idempotent Claude Code install script and document setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # DotFiles for Joel
+
+Personal configuration files, symlinked into `~/`. Each top-level directory holds config for one tool.
+
+## Contents
+
+| Directory | Purpose |
+|-----------|---------|
+| `alacritty/` | Alacritty terminal config |
+| `bash/` | Bash shell config |
+| `claude/` | Claude Code global config — `CLAUDE.md`, settings, commands, hooks, scripts |
+| `git/` | Git config |
+| `tmux/` | tmux config |
+| `vim/` | Vim config |
+| `vscode/` | VS Code settings and keybindings |
+
+## Claude Code
+
+The `claude/` directory is managed by a dedicated bootstrap script — see [`claude/README.md`](claude/README.md) for details. On a new machine:
+
+```bash
+./claude/install.sh
+```
+
+It symlinks `CLAUDE.md`, `settings.json`, `commands/`, `scripts/statusline.sh`, and `hooks/tmux-alert.sh` into `~/.claude/`. Idempotent and safe to re-run.
+
+Note: project-level `CLAUDE.md` files live in each project repo, not here.

--- a/claude/README.md
+++ b/claude/README.md
@@ -28,46 +28,36 @@ Personal configuration for [Claude Code](https://docs.anthropic.com/en/docs/clau
 
 ## Setup on a new machine
 
-Claude Code stores its config at `~/.claude/`. Symlink the files from this repo:
+Run the bootstrap script from the dotfiles repo root (or from inside `claude/`):
 
 ```bash
-# Symlink the global instructions
-ln -sf "$(pwd)/claude/CLAUDE.md" ~/.claude/CLAUDE.md
-
-# Symlink settings
-ln -sf "$(pwd)/claude/settings.json" ~/.claude/settings.json
-
-# Symlink commands directory (new commands are picked up automatically)
-ln -sf "$(pwd)/claude/commands" ~/.claude/commands
-
-# Symlink scripts
-mkdir -p ~/.claude/scripts
-ln -sf "$(pwd)/claude/scripts/statusline.sh" ~/.claude/scripts/statusline.sh
-chmod +x ~/.claude/scripts/statusline.sh
-
-# Symlink hooks
-mkdir -p ~/.claude/hooks
-ln -sf "$(pwd)/claude/hooks/tmux-alert.sh" ~/.claude/hooks/tmux-alert.sh
-chmod +x ~/.claude/hooks/tmux-alert.sh
+./claude/install.sh
 ```
 
-Or as a one-liner from the dotfiles repo root:
+The script is idempotent — safe to re-run. It symlinks `CLAUDE.md`, `settings.json`, `commands/`, `scripts/statusline.sh`, and `hooks/tmux-alert.sh` into `~/.claude/`, and backs up anything it would overwrite to `~/.claude/backups/install-<timestamp>/`.
+
+## Unified memory across parallel clones (GigMe only)
+
+Claude Code keys its memory dir by absolute CWD, so working on the same repo from multiple clones (`GigMe/`, `gigme2/`, `gigme3/`) would normally fragment memory across three isolated dirs. To fix this, each clone's memory dir is symlinked at a canonical shared location:
+
+```
+~/.claude/shared-memory/gigme/                            ← real dir, single source of truth
+~/.claude/projects/<encoded-GigMe>/memory   → shared-memory/gigme
+~/.claude/projects/<encoded-gigme2>/memory  → shared-memory/gigme
+~/.claude/projects/<encoded-gigme3>/memory  → shared-memory/gigme
+```
+
+This unification is **per-machine and GigMe-only**. It isn't managed by `install.sh` and isn't synced across machines (intentional — personal and work laptops stay independent). To add a new GigMe clone, symlink its memory dir after the first Claude Code session creates the project folder:
 
 ```bash
-ln -sf "$(pwd)/claude/CLAUDE.md" ~/.claude/CLAUDE.md && \
-ln -sf "$(pwd)/claude/settings.json" ~/.claude/settings.json && \
-ln -sf "$(pwd)/claude/commands" ~/.claude/commands && \
-mkdir -p ~/.claude/scripts ~/.claude/hooks && \
-ln -sf "$(pwd)/claude/scripts/statusline.sh" ~/.claude/scripts/statusline.sh && \
-chmod +x ~/.claude/scripts/statusline.sh && \
-ln -sf "$(pwd)/claude/hooks/tmux-alert.sh" ~/.claude/hooks/tmux-alert.sh && \
-chmod +x ~/.claude/hooks/tmux-alert.sh
+ln -sfn ~/.claude/shared-memory/gigme \
+  ~/.claude/projects/<encoded-path-of-new-clone>/memory
 ```
 
 ## Notes
 
 - `settings.json` contains plugin references that may need adjusting per machine (e.g. if plugins aren't installed yet)
-- `settings.local.json` (permissions) is intentionally excluded - it's machine-specific
+- `settings.local.json` (permissions) is intentionally excluded — it's machine-specific
 - Project-level `CLAUDE.md` files live in each repo, not here
-- The `projects/` directory (per-project memory) uses absolute paths and doesn't sync
+- `~/.claude/projects/` (session history and memory) is not touched by `install.sh` — too machine-specific and paths-based to sync via dotfiles
 - The tmux notification hook requires `monitor-bell on` and `bell-action any` in tmux (enabled by default in gpakosz/.tmux)

--- a/claude/install.sh
+++ b/claude/install.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Idempotent bootstrap for Claude Code config on a new machine.
+# Symlinks files from this dotfiles repo into ~/.claude/.
+# Safe to run multiple times. Backs up anything it would overwrite.
+#
+# Usage:  ./claude/install.sh      (from dotfiles repo root)
+#         ./install.sh             (from inside dotfiles/claude/)
+
+set -euo pipefail
+
+# Resolve repo paths regardless of where the script is invoked from.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLAUDE_HOME="${HOME}/.claude"
+BACKUP_DIR="${CLAUDE_HOME}/backups/install-$(date +%Y-%m-%d-%H%M%S)"
+
+# Output helpers
+already() { printf '  ✓ %s\n' "$1"; }
+linking() { printf '  → %s\n' "$1"; }
+backing() { printf '  ⚠ %s\n' "$1"; }
+header()  { printf '\n%s\n' "$1"; }
+
+ensure_dir() {
+  [[ -d "$1" ]] || mkdir -p "$1"
+}
+
+# Symlink $1 -> $2, backing up anything already at $2 that isn't already the right symlink.
+link() {
+  local src="$1" dest="$2"
+  ensure_dir "$(dirname "$dest")"
+
+  if [[ -L "$dest" ]]; then
+    local current
+    current="$(readlink "$dest")"
+    if [[ "$current" == "$src" ]]; then
+      already "$dest"
+      return 0
+    fi
+    backing "$dest (existing symlink -> $current, backing up)"
+    ensure_dir "$BACKUP_DIR"
+    mv "$dest" "$BACKUP_DIR/$(basename "$dest").symlink"
+  elif [[ -e "$dest" ]]; then
+    backing "$dest (existing file/dir, backing up)"
+    ensure_dir "$BACKUP_DIR"
+    mv "$dest" "$BACKUP_DIR/$(basename "$dest")"
+  fi
+
+  ln -s "$src" "$dest"
+  linking "$dest -> $src"
+}
+
+header "Claude Code dotfiles install"
+echo "  Source: $SCRIPT_DIR"
+echo "  Target: $CLAUDE_HOME"
+
+ensure_dir "$CLAUDE_HOME"
+
+header "Global instructions and settings"
+link "$SCRIPT_DIR/CLAUDE.md"     "$CLAUDE_HOME/CLAUDE.md"
+link "$SCRIPT_DIR/settings.json" "$CLAUDE_HOME/settings.json"
+
+header "Commands (directory-level symlink)"
+link "$SCRIPT_DIR/commands" "$CLAUDE_HOME/commands"
+
+header "Scripts"
+link "$SCRIPT_DIR/scripts/statusline.sh" "$CLAUDE_HOME/scripts/statusline.sh"
+chmod +x "$SCRIPT_DIR/scripts/statusline.sh"
+
+header "Hooks"
+link "$SCRIPT_DIR/hooks/tmux-alert.sh" "$CLAUDE_HOME/hooks/tmux-alert.sh"
+chmod +x "$SCRIPT_DIR/hooks/tmux-alert.sh"
+
+header "Done"
+if [[ -d "$BACKUP_DIR" ]]; then
+  echo "  Backups: $BACKUP_DIR"
+else
+  echo "  No backups needed (clean install or already linked)."
+fi
+echo
+echo "Note: settings.local.json (machine-specific permissions) is intentionally NOT symlinked."
+echo "Note: ~/.claude/projects/ (sessions + memory) is intentionally NOT touched."


### PR DESCRIPTION
Replace manual ln -sf snippets in claude/README.md with a proper bootstrap script. Script is idempotent, backs up anything it would overwrite, and prints clear status per step.

Also fills out the top-level dotfiles README (previously a one-line stub) with a Claude Code section, and documents the parallel-clone memory unification scheme (shared-memory/gigme symlinked into each clone's per-project memory dir).